### PR TITLE
Add Snippet Modification History with Restore Capability

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -50,12 +50,15 @@ func NewRouter(cfg RouterConfig) http.Handler {
 	tokenRepo := repository.NewTokenRepository(cfg.DB)
 	fileRepo := repository.NewSnippetFileRepository(cfg.DB)
 	settingsRepo := repository.NewSettingsRepository(cfg.DB)
+	historyRepo := repository.NewHistoryRepository(cfg.DB)
 
 	// Create services
 	snippetService := services.NewSnippetService(snippetRepo, cfg.Logger).
 		WithTagRepo(tagRepo).
 		WithFolderRepo(folderRepo).
 		WithFileRepo(fileRepo).
+		WithHistoryRepo(historyRepo).
+		WithSettingsRepo(settingsRepo).
 		WithMaxFiles(cfg.MaxFilesPerSnippet)
 
 	// Create backup service
@@ -135,6 +138,10 @@ func NewRouter(cfg RouterConfig) http.Handler {
 				r.Post("/favorite", snippetHandler.ToggleFavorite)
 				r.Post("/archive", snippetHandler.ToggleArchive)
 				r.Post("/duplicate", snippetHandler.Duplicate)
+				
+				// History routes
+				r.Get("/history", snippetHandler.GetHistory)
+				r.Post("/history/{history_id}/restore", snippetHandler.RestoreFromHistory)
 			})
 		})
 

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -187,11 +187,54 @@ CREATE INDEX IF NOT EXISTS idx_snippets_archived ON snippets(is_archived);
 ALTER TABLE settings ADD COLUMN archive_enabled INTEGER DEFAULT 0;
 `
 
+// Migration 4: Add snippet history support
+const addHistorySQL = `
+-- Create snippet_history table to track all modifications
+CREATE TABLE IF NOT EXISTS snippet_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snippet_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    content TEXT NOT NULL,
+    language TEXT DEFAULT 'plaintext',
+    is_favorite INTEGER DEFAULT 0,
+    is_public INTEGER DEFAULT 0,
+    is_archived INTEGER DEFAULT 0,
+    change_type TEXT DEFAULT 'update',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (snippet_id) REFERENCES snippets(id) ON DELETE CASCADE
+);
+
+-- Create snippet_files_history table to track file modifications
+CREATE TABLE IF NOT EXISTS snippet_files_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    history_id INTEGER NOT NULL,
+    snippet_id TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    content TEXT NOT NULL,
+    language TEXT NOT NULL,
+    sort_order INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (history_id) REFERENCES snippet_history(id) ON DELETE CASCADE,
+    FOREIGN KEY (snippet_id) REFERENCES snippets(id) ON DELETE CASCADE
+);
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_snippet_history_snippet_id ON snippet_history(snippet_id);
+CREATE INDEX IF NOT EXISTS idx_snippet_history_created ON snippet_history(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_snippet_files_history_history_id ON snippet_files_history(history_id);
+CREATE INDEX IF NOT EXISTS idx_snippet_files_history_snippet_id ON snippet_files_history(snippet_id);
+
+-- Add history_enabled column to settings
+ALTER TABLE settings ADD COLUMN history_enabled INTEGER DEFAULT 1;
+`
+
 // getMigrations returns all available migrations in order
 func getMigrations() []Migration {
 	return []Migration{
 		{Version: 1, Name: "initial_schema", SQL: initialSchemaSQL},
 		{Version: 2, Name: "add_snippet_files", SQL: addSnippetFilesSQL},
 		{Version: 3, Name: "add_archiving", SQL: addArchivingSQL},
+		{Version: 4, Name: "add_history", SQL: addHistorySQL},
 	}
 }

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -15,6 +15,7 @@ type Settings struct {
 	S3Region                string    `json:"s3_region"`
 	BackupEncryptionEnabled bool      `json:"backup_encryption_enabled"`
 	ArchiveEnabled          bool      `json:"archive_enabled"`
+	HistoryEnabled          bool      `json:"history_enabled"`
 	CreatedAt               time.Time `json:"created_at"`
 	UpdatedAt               time.Time `json:"updated_at"`
 }
@@ -33,4 +34,5 @@ type SettingsInput struct {
 	S3SecretAccessKey       string `json:"s3_secret_access_key,omitempty"` // Optional, only for updates
 	BackupEncryptionEnabled bool   `json:"backup_encryption_enabled"`
 	ArchiveEnabled          bool   `json:"archive_enabled"`
+	HistoryEnabled          bool   `json:"history_enabled"`
 }

--- a/internal/models/snippet.go
+++ b/internal/models/snippet.go
@@ -203,3 +203,31 @@ type S3RestoreResult struct {
 	StartedAt  time.Time `json:"started_at"`
 	FinishedAt time.Time `json:"finished_at"`
 }
+
+// SnippetHistory represents a historical version of a snippet
+type SnippetHistory struct {
+	ID          int64              `json:"id"`
+	SnippetID   string             `json:"snippet_id"`
+	Title       string             `json:"title"`
+	Description string             `json:"description"`
+	Content     string             `json:"content"`
+	Language    string             `json:"language"`
+	IsFavorite  bool               `json:"is_favorite"`
+	IsPublic    bool               `json:"is_public"`
+	IsArchived  bool               `json:"is_archived"`
+	ChangeType  string             `json:"change_type"` // 'create', 'update', 'delete'
+	CreatedAt   time.Time          `json:"created_at"`
+	Files       []SnippetFileHistory `json:"files,omitempty"`
+}
+
+// SnippetFileHistory represents a historical version of a snippet file
+type SnippetFileHistory struct {
+	ID         int64     `json:"id"`
+	HistoryID  int64     `json:"history_id"`
+	SnippetID  string    `json:"snippet_id"`
+	Filename   string    `json:"filename"`
+	Content    string    `json:"content"`
+	Language   string    `json:"language"`
+	SortOrder  int       `json:"sort_order"`
+	CreatedAt  time.Time `json:"created_at"`
+}

--- a/internal/repository/history_repo.go
+++ b/internal/repository/history_repo.go
@@ -1,0 +1,272 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/MohamedElashri/snipo/internal/models"
+)
+
+// HistoryRepository handles snippet history database operations
+type HistoryRepository struct {
+	db *sql.DB
+}
+
+// NewHistoryRepository creates a new history repository
+func NewHistoryRepository(db *sql.DB) *HistoryRepository {
+	return &HistoryRepository{db: db}
+}
+
+// CreateHistory creates a new history entry for a snippet
+func (r *HistoryRepository) CreateHistory(ctx context.Context, snippet *models.Snippet, changeType string) (int64, error) {
+	query := `
+		INSERT INTO snippet_history 
+		(snippet_id, title, description, content, language, is_favorite, is_public, is_archived, change_type)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`
+
+	result, err := r.db.ExecContext(ctx, query,
+		snippet.ID,
+		snippet.Title,
+		snippet.Description,
+		snippet.Content,
+		snippet.Language,
+		snippet.IsFavorite,
+		snippet.IsPublic,
+		snippet.IsArchived,
+		changeType,
+	)
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to create snippet history: %w", err)
+	}
+
+	historyID, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get history ID: %w", err)
+	}
+
+	return historyID, nil
+}
+
+// CreateFileHistory creates history entries for snippet files
+func (r *HistoryRepository) CreateFileHistory(ctx context.Context, historyID int64, files []models.SnippetFile) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	query := `
+		INSERT INTO snippet_files_history 
+		(history_id, snippet_id, filename, content, language, sort_order)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`
+
+	stmt, err := r.db.PrepareContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to prepare file history statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, file := range files {
+		_, err := stmt.ExecContext(ctx,
+			historyID,
+			file.SnippetID,
+			file.Filename,
+			file.Content,
+			file.Language,
+			file.SortOrder,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create file history: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// GetSnippetHistory retrieves all history entries for a snippet
+func (r *HistoryRepository) GetSnippetHistory(ctx context.Context, snippetID string, limit int) ([]models.SnippetHistory, error) {
+	if limit <= 0 {
+		limit = 50 // Default limit
+	}
+
+	query := `
+		SELECT id, snippet_id, title, description, content, language, 
+		       is_favorite, is_public, is_archived, change_type, created_at
+		FROM snippet_history
+		WHERE snippet_id = ?
+		ORDER BY created_at DESC
+		LIMIT ?
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, snippetID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get snippet history: %w", err)
+	}
+	defer rows.Close()
+
+	var history []models.SnippetHistory
+	for rows.Next() {
+		var h models.SnippetHistory
+		err := rows.Scan(
+			&h.ID,
+			&h.SnippetID,
+			&h.Title,
+			&h.Description,
+			&h.Content,
+			&h.Language,
+			&h.IsFavorite,
+			&h.IsPublic,
+			&h.IsArchived,
+			&h.ChangeType,
+			&h.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan history: %w", err)
+		}
+		history = append(history, h)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating history rows: %w", err)
+	}
+
+	// Fetch files for each history entry
+	for i := range history {
+		files, err := r.GetHistoryFiles(ctx, history[i].ID)
+		if err != nil {
+			// Log error but continue
+			continue
+		}
+		history[i].Files = files
+	}
+
+	return history, nil
+}
+
+// GetHistoryByID retrieves a specific history entry by ID
+func (r *HistoryRepository) GetHistoryByID(ctx context.Context, historyID int64) (*models.SnippetHistory, error) {
+	query := `
+		SELECT id, snippet_id, title, description, content, language,
+		       is_favorite, is_public, is_archived, change_type, created_at
+		FROM snippet_history
+		WHERE id = ?
+	`
+
+	var h models.SnippetHistory
+	err := r.db.QueryRowContext(ctx, query, historyID).Scan(
+		&h.ID,
+		&h.SnippetID,
+		&h.Title,
+		&h.Description,
+		&h.Content,
+		&h.Language,
+		&h.IsFavorite,
+		&h.IsPublic,
+		&h.IsArchived,
+		&h.ChangeType,
+		&h.CreatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get history entry: %w", err)
+	}
+
+	// Fetch files
+	files, err := r.GetHistoryFiles(ctx, h.ID)
+	if err == nil {
+		h.Files = files
+	}
+
+	return &h, nil
+}
+
+// GetHistoryFiles retrieves files for a specific history entry
+func (r *HistoryRepository) GetHistoryFiles(ctx context.Context, historyID int64) ([]models.SnippetFileHistory, error) {
+	query := `
+		SELECT id, history_id, snippet_id, filename, content, language, sort_order, created_at
+		FROM snippet_files_history
+		WHERE history_id = ?
+		ORDER BY sort_order ASC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, historyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get history files: %w", err)
+	}
+	defer rows.Close()
+
+	var files []models.SnippetFileHistory
+	for rows.Next() {
+		var f models.SnippetFileHistory
+		err := rows.Scan(
+			&f.ID,
+			&f.HistoryID,
+			&f.SnippetID,
+			&f.Filename,
+			&f.Content,
+			&f.Language,
+			&f.SortOrder,
+			&f.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan history file: %w", err)
+		}
+		files = append(files, f)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating history file rows: %w", err)
+	}
+
+	return files, nil
+}
+
+// DeleteSnippetHistory deletes all history entries for a snippet
+func (r *HistoryRepository) DeleteSnippetHistory(ctx context.Context, snippetID string) error {
+	query := `DELETE FROM snippet_history WHERE snippet_id = ?`
+
+	_, err := r.db.ExecContext(ctx, query, snippetID)
+	if err != nil {
+		return fmt.Errorf("failed to delete snippet history: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteOldHistory deletes history entries older than a specific date
+func (r *HistoryRepository) DeleteOldHistory(ctx context.Context, daysToKeep int) (int64, error) {
+	query := `
+		DELETE FROM snippet_history 
+		WHERE created_at < datetime('now', '-' || ? || ' days')
+	`
+
+	result, err := r.db.ExecContext(ctx, query, daysToKeep)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete old history: %w", err)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get affected rows: %w", err)
+	}
+
+	return affected, nil
+}
+
+// GetHistoryCount returns the total number of history entries for a snippet
+func (r *HistoryRepository) GetHistoryCount(ctx context.Context, snippetID string) (int, error) {
+	query := `SELECT COUNT(*) FROM snippet_history WHERE snippet_id = ?`
+
+	var count int
+	err := r.db.QueryRowContext(ctx, query, snippetID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get history count: %w", err)
+	}
+
+	return count, nil
+}

--- a/internal/repository/settings_repo.go
+++ b/internal/repository/settings_repo.go
@@ -23,7 +23,7 @@ func (r *SettingsRepository) Get(ctx context.Context) (*models.Settings, error) 
 	query := `
 		SELECT id, app_name, custom_css, theme, default_language, 
 		       s3_enabled, s3_endpoint, s3_bucket, s3_region, 
-		       backup_encryption_enabled, archive_enabled, created_at, updated_at
+		       backup_encryption_enabled, archive_enabled, history_enabled, created_at, updated_at
 		FROM settings
 		WHERE id = 1
 	`
@@ -41,6 +41,7 @@ func (r *SettingsRepository) Get(ctx context.Context) (*models.Settings, error) 
 		&settings.S3Region,
 		&settings.BackupEncryptionEnabled,
 		&settings.ArchiveEnabled,
+		&settings.HistoryEnabled,
 		&settings.CreatedAt,
 		&settings.UpdatedAt,
 	)
@@ -54,31 +55,15 @@ func (r *SettingsRepository) Get(ctx context.Context) (*models.Settings, error) 
 
 // Update updates application settings
 func (r *SettingsRepository) Update(ctx context.Context, input *models.SettingsInput) (*models.Settings, error) {
-	// First get existing settings to preserve fields if needed
-	// But here we assume input covers what we want to update
-	// Note: S3 secrets are environment variables usually, but stored in DB here?
-	// The schema has s3_endpoint but not secret key. Wait.
-	// Looking at schema:
-	// s3_endpoint, s3_bucket, s3_region.
-	// Where are keys?
-	// Config.go loads keys from ENV.
-	// Schema doesn't store keys.
-	// `internal/config/config.go` says:
-	// cfg.S3.AccessKeyID = os.Getenv("SNIPO_S3_ACCESS_KEY")
-	// But `settings` table has s3 related columns.
-	// "s3_endpoint TEXT DEFAULT '', s3_bucket TEXT DEFAULT '', s3_region TEXT DEFAULT 'us-east-1'"
-	// It seems the app might be moving to DB-based settings or supports both?
-	// Creating the repo based on the table schema.
-
 	query := `
 		UPDATE settings
 		SET app_name = ?, custom_css = ?, theme = ?, default_language = ?,
 		    s3_enabled = ?, s3_endpoint = ?, s3_bucket = ?, s3_region = ?,
-		    backup_encryption_enabled = ?, archive_enabled = ?, updated_at = CURRENT_TIMESTAMP
+		    backup_encryption_enabled = ?, archive_enabled = ?, history_enabled = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE id = 1
 		RETURNING id, app_name, custom_css, theme, default_language,
 		          s3_enabled, s3_endpoint, s3_bucket, s3_region,
-		          backup_encryption_enabled, archive_enabled, created_at, updated_at
+		          backup_encryption_enabled, archive_enabled, history_enabled, created_at, updated_at
 	`
 
 	settings := &models.Settings{}
@@ -93,6 +78,7 @@ func (r *SettingsRepository) Update(ctx context.Context, input *models.SettingsI
 		input.S3Region,
 		input.BackupEncryptionEnabled,
 		input.ArchiveEnabled,
+		input.HistoryEnabled,
 	).Scan(
 		&settings.ID,
 		&settings.AppName,
@@ -105,6 +91,7 @@ func (r *SettingsRepository) Update(ctx context.Context, input *models.SettingsI
 		&settings.S3Region,
 		&settings.BackupEncryptionEnabled,
 		&settings.ArchiveEnabled,
+		&settings.HistoryEnabled,
 		&settings.CreatedAt,
 		&settings.UpdatedAt,
 	)

--- a/internal/web/static/css/app.css
+++ b/internal/web/static/css/app.css
@@ -2189,3 +2189,201 @@ body {
     display: none !important;
   }
 }
+
+/* History styles */
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.history-entry {
+  border: 1px solid var(--snipo-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.history-entry-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background: var(--snipo-bg-secondary);
+  gap: 1rem;
+}
+
+.history-entry-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.history-entry-meta {
+  font-size: 0.875rem;
+  color: var(--snipo-text-secondary);
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.history-entry-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.history-entry-preview {
+  padding: 1rem;
+  border-top: 1px solid var(--snipo-border);
+}
+
+.history-preview-section {
+  margin-bottom: 1rem;
+}
+
+.history-preview-section:last-child {
+  margin-bottom: 0;
+}
+
+.history-code-preview {
+  background: var(--snipo-bg);
+  border: 1px solid var(--snipo-border);
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-size: 0.875rem;
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 200px;
+  overflow-y: auto;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--snipo-primary);
+  color: white;
+}
+
+.btn-sm {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  border: 1px solid var(--snipo-border);
+  background: var(--snipo-bg);
+  color: var(--snipo-text);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.btn-sm:hover {
+  background: var(--snipo-bg-secondary);
+}
+
+.btn-sm.btn-primary {
+  background: var(--snipo-primary);
+  color: white;
+  border-color: var(--snipo-primary);
+}
+
+.btn-sm.btn-primary:hover {
+  opacity: 0.9;
+}
+
+.badge-current {
+  background: var(--snipo-success);
+}
+
+/* History detail view */
+.history-detail-section {
+  margin-bottom: 1.5rem;
+}
+
+.history-detail-section h4 {
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--snipo-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.history-detail-content {
+  border: 1px solid var(--snipo-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.history-detail-file-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: var(--snipo-bg-secondary);
+  border-bottom: 1px solid var(--snipo-border);
+}
+
+.history-file-name {
+  font-weight: 600;
+  margin-right: 0.75rem;
+}
+
+.history-file-language {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  background: var(--snipo-primary);
+  color: white;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+}
+
+.history-detail-code {
+  margin: 0;
+  padding: 1rem;
+  background: var(--snipo-bg);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+/* Restore confirmation */
+.restore-warning {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.restore-info {
+  background: var(--snipo-bg-secondary);
+  border: 1px solid var(--snipo-border);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.restore-info-item {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--snipo-border);
+}
+
+.restore-info-item:last-child {
+  border-bottom: none;
+}
+
+.restore-notice {
+  background: var(--snipo-warning-bg, #fef3c7);
+  border: 1px solid var(--snipo-warning, #f59e0b);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: var(--snipo-text);
+}
+
+[data-theme="dark"] .restore-notice {
+  background: rgba(245, 158, 11, 0.1);
+}

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -467,6 +467,17 @@
                         <span x-text="editingSnippet?.is_archived ? 'Unarchive' : 'Archive'"></span>
                     </button>
 
+                    <!-- History button -->
+                    <button class="btn-action" @click="openHistory(editingSnippet)"
+                        x-show="editingSnippet?.id && settings.history_enabled" title="View History">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M3 3v5h5"></path>
+                            <path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"></path>
+                            <polyline points="12 7 12 12 15 15"></polyline>
+                        </svg>
+                        <span>History</span>
+                    </button>
+
                     <button class="btn-action danger" @click="confirmDelete(editingSnippet)" x-show="editingSnippet?.id"
                         title="Delete">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -872,6 +883,13 @@
                         <p class="text-sm text-muted" style="margin-top: 0.25rem;">Allow snippets to be archived instead
                             of permanently deleted.</p>
                     </div>
+                    <div class="editor-field" style="margin-top: 1rem;">
+                        <label class="checkbox-label">
+                            <input type="checkbox" x-model="settings.history_enabled" @change="updateSettings()">
+                            <span>Enable Modification History</span>
+                        </label>
+                        <p class="text-sm text-muted" style="margin-top: 0.25rem;">Track all changes to snippets. Previous versions can be viewed and restored at any time.</p>
+                    </div>
                 </div>
 
                 <!-- Password tab -->
@@ -1192,6 +1210,192 @@
             <div class="modal-footer">
                 <button @click="showTagModal = false">Cancel</button>
                 <button class="btn-primary" @click="saveTag()">Save</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- History modal -->
+    <div class="modal-backdrop" x-show="showHistory" x-cloak @click.self="closeHistory()">
+        <div class="modal" style="max-width: 900px; max-height: 80vh;">
+            <div class="modal-header">
+                <h3>Snippet History</h3>
+                <button class="btn-icon" @click="closeHistory()">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body" style="overflow-y: auto; max-height: calc(80vh - 120px);">
+                <p class="text-sm text-muted" x-show="!historyLoading && history.length === 0">
+                    No history available for this snippet yet.
+                </p>
+                <p class="text-sm text-muted" x-show="historyLoading">
+                    Loading history...
+                </p>
+                <div class="history-list" x-show="!historyLoading && history.length > 0">
+                    <template x-for="(entry, index) in history" :key="entry.id">
+                        <div class="history-entry">
+                            <div class="history-entry-header">
+                                <div>
+                                    <div class="history-entry-title" x-text="entry.title || 'Untitled'"></div>
+                                    <div class="history-entry-meta">
+                                        <span x-text="formatDate(entry.created_at)"></span>
+                                        <span x-show="entry.change_type === 'create'" class="badge">Created</span>
+                                        <span x-show="entry.change_type === 'update'" class="badge">Updated</span>
+                                        <span x-show="index === 0" class="badge badge-current">Current</span>
+                                    </div>
+                                </div>
+                                <div class="history-entry-actions">
+                                    <button class="btn-sm" @click="viewHistoryDetail(entry)">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+                                            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                                            <circle cx="12" cy="12" r="3"></circle>
+                                        </svg>
+                                        View Full
+                                    </button>
+                                    <button class="btn-sm btn-primary" @click="confirmRestoreHistory(entry)"
+                                        x-show="index > 0">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+                                            <polyline points="1 4 1 10 7 10"></polyline>
+                                            <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+                                        </svg>
+                                        Restore
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- History Detail modal -->
+    <div class="modal-backdrop" x-show="showHistoryDetail" x-cloak @click.self="closeHistoryDetail()">
+        <div class="modal" style="max-width: 1000px; max-height: 85vh;">
+            <div class="modal-header">
+                <div>
+                    <h3 x-text="viewingHistoryEntry?.title || 'Untitled'"></h3>
+                    <p class="text-sm text-muted" style="margin-top: 0.25rem;">
+                        <span x-text="formatDate(viewingHistoryEntry?.created_at)"></span>
+                        <span x-show="viewingHistoryEntry?.change_type === 'create'"> • Created</span>
+                        <span x-show="viewingHistoryEntry?.change_type === 'update'"> • Updated</span>
+                    </p>
+                </div>
+                <button class="btn-icon" @click="closeHistoryDetail()">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body" style="overflow-y: auto; max-height: calc(85vh - 150px);">
+                <div class="history-detail-section" x-show="viewingHistoryEntry?.description">
+                    <h4>Description</h4>
+                    <p x-text="viewingHistoryEntry?.description"></p>
+                </div>
+
+                <!-- Single file/content view -->
+                <div class="history-detail-section" x-show="!viewingHistoryEntry?.files || viewingHistoryEntry?.files.length === 0">
+                    <h4>Content</h4>
+                    <div class="history-detail-content">
+                        <div class="history-detail-file-header">
+                            <span class="history-file-language" x-text="viewingHistoryEntry?.language || 'plaintext'"></span>
+                            <button class="btn-sm" @click="copyHistoryContent(viewingHistoryEntry?.content)">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+                                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                </svg>
+                                Copy
+                            </button>
+                        </div>
+                        <pre class="history-detail-code"><code x-text="viewingHistoryEntry?.content"></code></pre>
+                    </div>
+                </div>
+
+                <!-- Multiple files view -->
+                <div class="history-detail-section" x-show="viewingHistoryEntry?.files && viewingHistoryEntry?.files.length > 0">
+                    <h4>Files (<span x-text="viewingHistoryEntry?.files.length"></span>)</h4>
+                    <template x-for="(file, idx) in viewingHistoryEntry?.files" :key="file.id">
+                        <div class="history-detail-content" style="margin-bottom: 1rem;">
+                            <div class="history-detail-file-header">
+                                <div>
+                                    <span class="history-file-name" x-text="file.filename"></span>
+                                    <span class="history-file-language" x-text="file.language"></span>
+                                </div>
+                                <button class="btn-sm" @click="copyHistoryContent(file.content)">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+                                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                    </svg>
+                                    Copy
+                                </button>
+                            </div>
+                            <pre class="history-detail-code"><code x-text="file.content"></code></pre>
+                        </div>
+                    </template>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button @click="closeHistoryDetail()">Close</button>
+                <button class="btn-primary" @click="confirmRestoreHistory(viewingHistoryEntry)"
+                    x-show="viewingHistoryEntry && !viewingHistoryEntry.is_current">
+                    Restore This Version
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Restore Confirmation modal -->
+    <div class="modal-backdrop" x-show="showRestoreConfirm" x-cloak @click.self="showRestoreConfirm = false">
+        <div class="modal" style="max-width: 500px;">
+            <div class="modal-header">
+                <h3>Confirm Restore</h3>
+                <button class="btn-icon" @click="showRestoreConfirm = false">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="restore-warning">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="48" height="48" style="color: var(--snipo-warning);">
+                        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+                        <line x1="12" y1="9" x2="12" y2="13"></line>
+                        <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                    </svg>
+                </div>
+                <h4 style="text-align: center; margin: 1rem 0;">Restore Previous Version?</h4>
+                <p style="text-align: center; color: var(--snipo-text-secondary); margin-bottom: 1rem;">
+                    This will restore the snippet to:
+                </p>
+                <div class="restore-info">
+                    <div class="restore-info-item">
+                        <strong>Title:</strong> <span x-text="restoringHistoryEntry?.title"></span>
+                    </div>
+                    <div class="restore-info-item">
+                        <strong>Version from:</strong> <span x-text="formatDate(restoringHistoryEntry?.created_at)"></span>
+                    </div>
+                    <div class="restore-info-item" x-show="restoringHistoryEntry?.files && restoringHistoryEntry.files.length > 0">
+                        <strong>Files:</strong> <span x-text="restoringHistoryEntry?.files.length"></span>
+                    </div>
+                </div>
+                <div class="restore-notice">
+                    <strong>Important:</strong> The current version will be saved to history before restoring.
+                    You can always restore back to it later.
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button @click="showRestoreConfirm = false">Cancel</button>
+                <button class="btn-primary" @click="executeRestore()">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16">
+                        <polyline points="1 4 1 10 7 10"></polyline>
+                        <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+                    </svg>
+                    Restore Now
+                </button>
             </div>
         </div>
     </div>

--- a/migrations/003_add_history.sql
+++ b/migrations/003_add_history.sql
@@ -1,0 +1,41 @@
+-- Snipo Migration: Add Snippet History
+-- Version: 3
+
+-- Create snippet_history table to track all modifications
+CREATE TABLE IF NOT EXISTS snippet_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snippet_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    content TEXT NOT NULL,
+    language TEXT DEFAULT 'plaintext',
+    is_favorite INTEGER DEFAULT 0,
+    is_public INTEGER DEFAULT 0,
+    is_archived INTEGER DEFAULT 0,
+    change_type TEXT DEFAULT 'update', -- 'create', 'update', 'delete'
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (snippet_id) REFERENCES snippets(id) ON DELETE CASCADE
+);
+
+-- Create snippet_files_history table to track file modifications
+CREATE TABLE IF NOT EXISTS snippet_files_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    history_id INTEGER NOT NULL,
+    snippet_id TEXT NOT NULL,
+    filename TEXT NOT NULL,
+    content TEXT NOT NULL,
+    language TEXT NOT NULL,
+    sort_order INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (history_id) REFERENCES snippet_history(id) ON DELETE CASCADE,
+    FOREIGN KEY (snippet_id) REFERENCES snippets(id) ON DELETE CASCADE
+);
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_snippet_history_snippet_id ON snippet_history(snippet_id);
+CREATE INDEX IF NOT EXISTS idx_snippet_history_created ON snippet_history(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_snippet_files_history_history_id ON snippet_files_history(history_id);
+CREATE INDEX IF NOT EXISTS idx_snippet_files_history_snippet_id ON snippet_files_history(snippet_id);
+
+-- Add history_enabled column to settings
+ALTER TABLE settings ADD COLUMN history_enabled INTEGER DEFAULT 1;


### PR DESCRIPTION
This PR implements a history tracking system for snippets. Users can now view all previous versions of their snippets and restore them at any time, ensuring no data is ever lost. 

## What is Added ?

### Backend

- **Database Schema**: New `snippet_history` and `snippet_files_history` tables with proper indexing
- **Automatic Tracking**: Captures snapshot on every create/update operation
- **History Repository**: Full CRUD operations for history management
- **Service Layer**: Automatic save before updates, conditional tracking based on settings
- API Endpoints:
  - `GET /api/v1/snippets/{id}/history`- Retrieve version history
  - `POST /api/v1/snippets/{id}/history/{history_id}/restore` - Restore specific version
- **Settings Control**: New `history_enabled` flag (defaults to `enabled`)


### Frontend

- **History Button**: Clock icon in snippet toolbar (only visible when history enabled)
- **History List Modal**: Shows all versions with timestamps and change types
- **Detail View Modal**: Full content display for all files with copy buttons
- **Restore Confirmation**: Warning dialog with version info before restore


The feature is backward compatible and opt-in/out via settings.


This closes #10 



