### PR TITLE
Fix the Dockerfile have hardcoded arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,12 @@ COPY . .
 ARG VERSION=dev
 ARG COMMIT=unknown
 
+# Build arguments for target platform (automatically set by Docker Buildx)
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
 # Build the binary with optimizations
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT}" \
     -o /snipo \
     ./cmd/server

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run test test-coverage test-short coverage coverage-func lint clean docker docker-run docker-stop dev migrate migrate-down
+.PHONY: all build run test test-coverage test-short coverage coverage-func lint clean docker docker-multiarch docker-run docker-stop dev migrate migrate-down
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -44,6 +44,14 @@ docker:
 	docker build -t snipo:$(VERSION) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg COMMIT=$(COMMIT) .
+
+docker-multiarch:
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg COMMIT=$(COMMIT) \
+		-t snipo:$(VERSION) \
+		--load .
 
 docker-run:
 	docker compose up -d


### PR DESCRIPTION
The Dockerfile hardcodes `GOARCH=amd64`, so even though our GitHub Actions workflow builds for multiple platforms (`linux/amd64`,`linux/arm64`), the binary inside the container is always compiled for AMD64 architecture. 

I missed that because when I try on macOS, I forgot that Apple Silicon Macs have Rosetta 2, which can transparently run AMD64 binaries on ARM64 images. That's why I didn't catch this before. 

This PR hopefully fix this and will be released in `v1.2.1` 


