### PR TITLE
fix: adjust spacing and line height in editor toolbar 

### DIFF
--- a/internal/web/static/css/components/editor.css
+++ b/internal/web/static/css/components/editor.css
@@ -11,7 +11,7 @@
 .editor-toolbar {
   display: flex;
   align-items: center;
-  gap: 0.05rem;
+  gap: 0.75rem;
   padding: 0.25rem 0.5rem;
   background: var(--pico-card-background-color);
   border-bottom: 1px solid var(--pico-muted-border-color);
@@ -45,8 +45,8 @@
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
-  line-height: 1.8;
-  min-height: 36px;
+  line-height: 1.4;
+  min-height: 40px;
   max-height: 120px;
   box-sizing: border-box;
 }
@@ -60,7 +60,7 @@
   flex: 1;
   font-size: 1rem;
   font-weight: 600;
-  margin: 0;
+  margin: 0 0 0 0.5rem;
   padding: 0.2rem 0;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
This fixes the spacing problems reported into #50 