### PR TITLE
fix: allow multi-word tags in snippet validation

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -47,7 +47,7 @@ var allowedLanguages = map[string]bool{
 }
 
 // tagRegex validates tag names
-var tagRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+var tagRegex = regexp.MustCompile(`^[a-zA-Z0-9_ -]+$`)
 
 // ValidateSnippetInput validates snippet input
 func ValidateSnippetInput(input *models.SnippetInput) ValidationErrors {
@@ -113,7 +113,7 @@ func ValidateSnippetInput(input *models.SnippetInput) ValidationErrors {
 		if len(tag) > 50 {
 			errs = append(errs, ValidationError{Field: "tags", Message: "Tag name must be less than 50 characters"})
 		} else if !tagRegex.MatchString(tag) {
-			errs = append(errs, ValidationError{Field: "tags", Message: "Tag can only contain letters, numbers, underscores, and hyphens"})
+			errs = append(errs, ValidationError{Field: "tags", Message: "Tag can only contain letters, numbers, spaces, underscores, and hyphens"})
 		}
 	}
 

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -206,7 +206,7 @@ func TestValidateSnippetInput_ValidTags(t *testing.T) {
 		Title:    "Valid Title",
 		Content:  "content",
 		Language: "plaintext",
-		Tags:     []string{"valid-tag", "another_tag", "tag123"},
+		Tags:     []string{"valid-tag", "another_tag", "tag123", "hi there"},
 	}
 
 	errs := ValidateSnippetInput(input)
@@ -215,12 +215,26 @@ func TestValidateSnippetInput_ValidTags(t *testing.T) {
 	}
 }
 
+func TestValidateSnippetInput_MultiWordTags(t *testing.T) {
+	input := &models.SnippetInput{
+		Title:    "Valid Title",
+		Content:  "content",
+		Language: "plaintext",
+		Tags:     []string{"multi word tag", "another tag", "one more"},
+	}
+
+	errs := ValidateSnippetInput(input)
+	if errs.HasErrors() {
+		t.Errorf("expected no errors for multi-word tags, got: %v", errs)
+	}
+}
+
 func TestValidateSnippetInput_InvalidTagCharacters(t *testing.T) {
 	input := &models.SnippetInput{
 		Title:    "Valid Title",
 		Content:  "content",
 		Language: "plaintext",
-		Tags:     []string{"invalid tag"}, // Space not allowed
+		Tags:     []string{"invalid@tag"}, // Special characters not allowed
 	}
 
 	errs := ValidateSnippetInput(input)
@@ -588,7 +602,7 @@ func TestValidateTagInput(t *testing.T) {
 		{"valid alphanumeric", "test123", false},
 		{"empty tag", "", true},
 		{"too long", strings.Repeat("a", 51), true},
-		{"with spaces", "test tag", true},
+		{"with spaces", "test tag", false},
 		{"with special chars", "test@tag", true},
 		{"with dots", "test.tag", true},
 	}


### PR DESCRIPTION
This fix the problem reported in #51 