### PR TITLE
fix: correct docker volume mount path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Or using Docker directly:
 ```bash
 docker run -d \
   -p 8080:8080 \
-  -v snipo-data:/app/data \
+  -v snipo-data:/data \
   -e SNIPO_MASTER_PASSWORD=your-secure-password \
   -e SNIPO_SESSION_SECRET=$(openssl rand -hex 32) \
   --name snipo \


### PR DESCRIPTION
This PR fixes the docker run example in `README.md` incorrectly showing the volume mount as `/app/data`, but the application expects data at /data (as defined in `Dockerfile` `WORKDIR` and `SNIPO_DB_PATH` environment variable).

This closes #70 