### PR TITLE
Fix snippy build and highlight code rendering

### DIFF
--- a/tui/.gitignore
+++ b/tui/.gitignore
@@ -1,6 +1,6 @@
 # Binaries
 bin/
-snippy
+/snippy
 *.exe
 *.exe~
 *.dll

--- a/tui/Makefile
+++ b/tui/Makefile
@@ -35,7 +35,7 @@ install: build
 
 run:
 	@echo "Running $(BINARY_NAME)..."
-	go run ./cmd/snipo-tui
+	go run ./cmd/snippy
 
 clean:
 	@echo "Cleaning build artifacts..."

--- a/tui/cmd/snippy/main.go
+++ b/tui/cmd/snippy/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MohamedElashri/snipo/tui/internal/app"
+	"github.com/MohamedElashri/snipo/tui/internal/config"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "config" {
+		if err := runConfigWizard(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if err := app.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runConfigWizard() error {
+	reader := bufio.NewReader(os.Stdin)
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Snippy Configuration Wizard")
+	fmt.Println("---------------------------")
+
+	fmt.Printf("Server URL [%s]: ", cfg.ServerURL)
+	url, _ := reader.ReadString('\n')
+	url = strings.TrimSpace(url)
+	if url != "" {
+		cfg.ServerURL = url
+	}
+
+	keyHint := ""
+	if cfg.APIKey != "" {
+		keyHint = "(set)"
+	}
+	fmt.Printf("API Key %s: ", keyHint) 
+	key, _ := reader.ReadString('\n')
+	key = strings.TrimSpace(key)
+	if key != "" {
+		cfg.APIKey = key
+	}
+
+	if err := cfg.Save(); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	fmt.Println("Configuration saved successfully!")
+	return nil
+}

--- a/tui/internal/ui/styles.go
+++ b/tui/internal/ui/styles.go
@@ -64,8 +64,9 @@ var (
 			MarginBottom(1)
 
 	codeBlockStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("235")).
 			Foreground(lipgloss.Color("252")).
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("62")).
 			Padding(1, 2).
 			MarginTop(1).
 			MarginBottom(1)


### PR DESCRIPTION
This PR fix tui app `snippy` missing `cmd/snippy/main.go` because of aggressive `tui/.gitignore` rule that preventing the file from being committed. 

Also fix problem with highlight container creates a lot of ugly black boxes for borders and whitespaces. 