### PR TITLE
Add copy button to snippet cards with multi-file support and optional first-line exclusion

### DIFF
--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -261,6 +261,13 @@ const addDisableLoginSQL = `
 ALTER TABLE settings ADD COLUMN disable_login INTEGER DEFAULT 0 NOT NULL;
 `
 
+// Migration 8: Add exclude_first_line_on_copy setting
+
+const addExcludeFirstLineSQL = `
+-- Add exclude_first_line_on_copy column to settings table
+ALTER TABLE settings ADD COLUMN exclude_first_line_on_copy INTEGER DEFAULT 0 NOT NULL;
+`
+
 // getMigrations returns all available migrations in order
 func getMigrations() []Migration {
 	return []Migration{
@@ -271,5 +278,6 @@ func getMigrations() []Migration {
 		{Version: 5, Name: "add_editor_settings", SQL: addEditorSettingsSQL},
 		{Version: 6, Name: "add_markdown_settings", SQL: addMarkdownSettingsSQL},
 		{Version: 7, Name: "add_disable_login", SQL: addDisableLoginSQL},
+		{Version: 8, Name: "add_exclude_first_line", SQL: addExcludeFirstLineSQL},
 	}
 }

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -4,61 +4,63 @@ import "time"
 
 // Settings represents application settings
 type Settings struct {
-	ID                      int64     `json:"id"`
-	AppName                 string    `json:"app_name"`
-	CustomCSS               string    `json:"custom_css"`
-	Theme                   string    `json:"theme"`
-	DefaultLanguage         string    `json:"default_language"`
-	S3Enabled               bool      `json:"s3_enabled"`
-	S3Endpoint              string    `json:"s3_endpoint"`
-	S3Bucket                string    `json:"s3_bucket"`
-	S3Region                string    `json:"s3_region"`
-	BackupEncryptionEnabled bool      `json:"backup_encryption_enabled"`
-	ArchiveEnabled          bool      `json:"archive_enabled"`
-	HistoryEnabled          bool      `json:"history_enabled"`
-	DisableLogin            bool      `json:"disable_login"`
-	EditorFontSize          int       `json:"editor_font_size"`
-	EditorTabSize           int       `json:"editor_tab_size"`
-	EditorTheme             string    `json:"editor_theme"`
-	EditorWordWrap          bool      `json:"editor_word_wrap"`
-	EditorShowPrintMargin   bool      `json:"editor_show_print_margin"`
-	EditorShowGutter        bool      `json:"editor_show_gutter"`
-	EditorShowIndentGuides  bool      `json:"editor_show_indent_guides"`
-	EditorHighlightActiveLine bool    `json:"editor_highlight_active_line"`
-	EditorUseSoftTabs       bool      `json:"editor_use_soft_tabs"`
-	EditorEnableSnippets    bool      `json:"editor_enable_snippets"`
-	EditorEnableLiveAutocompletion bool `json:"editor_enable_live_autocompletion"`
-	MarkdownFontSize        int       `json:"markdown_font_size"`
-	CreatedAt               time.Time `json:"created_at"`
-	UpdatedAt               time.Time `json:"updated_at"`
+	ID                             int64     `json:"id"`
+	AppName                        string    `json:"app_name"`
+	CustomCSS                      string    `json:"custom_css"`
+	Theme                          string    `json:"theme"`
+	DefaultLanguage                string    `json:"default_language"`
+	S3Enabled                      bool      `json:"s3_enabled"`
+	S3Endpoint                     string    `json:"s3_endpoint"`
+	S3Bucket                       string    `json:"s3_bucket"`
+	S3Region                       string    `json:"s3_region"`
+	BackupEncryptionEnabled        bool      `json:"backup_encryption_enabled"`
+	ArchiveEnabled                 bool      `json:"archive_enabled"`
+	HistoryEnabled                 bool      `json:"history_enabled"`
+	DisableLogin                   bool      `json:"disable_login"`
+	EditorFontSize                 int       `json:"editor_font_size"`
+	EditorTabSize                  int       `json:"editor_tab_size"`
+	EditorTheme                    string    `json:"editor_theme"`
+	EditorWordWrap                 bool      `json:"editor_word_wrap"`
+	EditorShowPrintMargin          bool      `json:"editor_show_print_margin"`
+	EditorShowGutter               bool      `json:"editor_show_gutter"`
+	EditorShowIndentGuides         bool      `json:"editor_show_indent_guides"`
+	EditorHighlightActiveLine      bool      `json:"editor_highlight_active_line"`
+	EditorUseSoftTabs              bool      `json:"editor_use_soft_tabs"`
+	EditorEnableSnippets           bool      `json:"editor_enable_snippets"`
+	EditorEnableLiveAutocompletion bool      `json:"editor_enable_live_autocompletion"`
+	MarkdownFontSize               int       `json:"markdown_font_size"`
+	ExcludeFirstLineOnCopy         bool      `json:"exclude_first_line_on_copy"`
+	CreatedAt                      time.Time `json:"created_at"`
+	UpdatedAt                      time.Time `json:"updated_at"`
 }
 
 // SettingsInput represents input for updating settings
 type SettingsInput struct {
-	AppName                 string `json:"app_name"`
-	CustomCSS               string `json:"custom_css"`
-	Theme                   string `json:"theme"`
-	DefaultLanguage         string `json:"default_language"`
-	S3Enabled               bool   `json:"s3_enabled"`
-	S3Endpoint              string `json:"s3_endpoint"`
-	S3Bucket                string `json:"s3_bucket"`
-	S3Region                string `json:"s3_region"`
-	S3AccessKeyID           string `json:"s3_access_key_id,omitempty"`     // Optional, only for updates
-	S3SecretAccessKey       string `json:"s3_secret_access_key,omitempty"` // Optional, only for updates
-	BackupEncryptionEnabled bool   `json:"backup_encryption_enabled"`
-	ArchiveEnabled          bool   `json:"archive_enabled"`
-	HistoryEnabled          bool   `json:"history_enabled"`
-	DisableLogin            bool   `json:"disable_login"`
-	EditorFontSize          int    `json:"editor_font_size"`
-	EditorTabSize           int    `json:"editor_tab_size"`
-	EditorTheme             string `json:"editor_theme"`
-	EditorWordWrap          bool   `json:"editor_word_wrap"`
-	EditorShowPrintMargin   bool   `json:"editor_show_print_margin"`
-	EditorShowGutter        bool   `json:"editor_show_gutter"`
-	EditorShowIndentGuides  bool   `json:"editor_show_indent_guides"`
-	EditorHighlightActiveLine bool `json:"editor_highlight_active_line"`
-	EditorUseSoftTabs       bool   `json:"editor_use_soft_tabs"`
-	EditorEnableSnippets    bool   `json:"editor_enable_snippets"`
-	EditorEnableLiveAutocompletion bool `json:"editor_enable_live_autocompletion"`
-	MarkdownFontSize        int    `json:"markdown_font_size"`
+	AppName                        string `json:"app_name"`
+	CustomCSS                      string `json:"custom_css"`
+	Theme                          string `json:"theme"`
+	DefaultLanguage                string `json:"default_language"`
+	S3Enabled                      bool   `json:"s3_enabled"`
+	S3Endpoint                     string `json:"s3_endpoint"`
+	S3Bucket                       string `json:"s3_bucket"`
+	S3Region                       string `json:"s3_region"`
+	S3AccessKeyID                  string `json:"s3_access_key_id,omitempty"`     // Optional, only for updates
+	S3SecretAccessKey              string `json:"s3_secret_access_key,omitempty"` // Optional, only for updates
+	BackupEncryptionEnabled        bool   `json:"backup_encryption_enabled"`
+	ArchiveEnabled                 bool   `json:"archive_enabled"`
+	HistoryEnabled                 bool   `json:"history_enabled"`
+	DisableLogin                   bool   `json:"disable_login"`
+	EditorFontSize                 int    `json:"editor_font_size"`
+	EditorTabSize                  int    `json:"editor_tab_size"`
+	EditorTheme                    string `json:"editor_theme"`
+	EditorWordWrap                 bool   `json:"editor_word_wrap"`
+	EditorShowPrintMargin          bool   `json:"editor_show_print_margin"`
+	EditorShowGutter               bool   `json:"editor_show_gutter"`
+	EditorShowIndentGuides         bool   `json:"editor_show_indent_guides"`
+	EditorHighlightActiveLine      bool   `json:"editor_highlight_active_line"`
+	EditorUseSoftTabs              bool   `json:"editor_use_soft_tabs"`
+	EditorEnableSnippets           bool   `json:"editor_enable_snippets"`
+	EditorEnableLiveAutocompletion bool   `json:"editor_enable_live_autocompletion"`
+	MarkdownFontSize               int    `json:"markdown_font_size"`
+	ExcludeFirstLineOnCopy         bool   `json:"exclude_first_line_on_copy"`
 }

--- a/internal/repository/settings_repo.go
+++ b/internal/repository/settings_repo.go
@@ -28,7 +28,8 @@ func (r *SettingsRepository) Get(ctx context.Context) (*models.Settings, error) 
 		       editor_font_size, editor_tab_size, editor_theme, editor_word_wrap,
 		       editor_show_print_margin, editor_show_gutter, editor_show_indent_guides,
 		       editor_highlight_active_line, editor_use_soft_tabs, editor_enable_snippets,
-		       editor_enable_live_autocompletion, markdown_font_size, created_at, updated_at
+		       editor_enable_live_autocompletion, markdown_font_size, exclude_first_line_on_copy,
+		       created_at, updated_at
 		FROM settings
 		WHERE id = 1
 	`
@@ -60,6 +61,7 @@ func (r *SettingsRepository) Get(ctx context.Context) (*models.Settings, error) 
 		&settings.EditorEnableSnippets,
 		&settings.EditorEnableLiveAutocompletion,
 		&settings.MarkdownFontSize,
+		&settings.ExcludeFirstLineOnCopy,
 		&settings.CreatedAt,
 		&settings.UpdatedAt,
 	)
@@ -82,7 +84,8 @@ func (r *SettingsRepository) Update(ctx context.Context, input *models.SettingsI
 		    editor_font_size = ?, editor_tab_size = ?, editor_theme = ?, editor_word_wrap = ?,
 		    editor_show_print_margin = ?, editor_show_gutter = ?, editor_show_indent_guides = ?,
 		    editor_highlight_active_line = ?, editor_use_soft_tabs = ?, editor_enable_snippets = ?,
-		    editor_enable_live_autocompletion = ?, markdown_font_size = ?, updated_at = CURRENT_TIMESTAMP
+		    editor_enable_live_autocompletion = ?, markdown_font_size = ?, exclude_first_line_on_copy = ?,
+		    updated_at = CURRENT_TIMESTAMP
 		WHERE id = 1
 		RETURNING id, app_name, custom_css, theme, default_language,
 		          s3_enabled, s3_endpoint, s3_bucket, s3_region,
@@ -91,7 +94,8 @@ func (r *SettingsRepository) Update(ctx context.Context, input *models.SettingsI
 		          editor_font_size, editor_tab_size, editor_theme, editor_word_wrap,
 		          editor_show_print_margin, editor_show_gutter, editor_show_indent_guides,
 		          editor_highlight_active_line, editor_use_soft_tabs, editor_enable_snippets,
-		          editor_enable_live_autocompletion, markdown_font_size, created_at, updated_at
+		          editor_enable_live_autocompletion, markdown_font_size, exclude_first_line_on_copy,
+		          created_at, updated_at
 	`
 
 	settings := &models.Settings{}
@@ -120,6 +124,7 @@ func (r *SettingsRepository) Update(ctx context.Context, input *models.SettingsI
 		input.EditorEnableSnippets,
 		input.EditorEnableLiveAutocompletion,
 		input.MarkdownFontSize,
+		input.ExcludeFirstLineOnCopy,
 	).Scan(
 		&settings.ID,
 		&settings.AppName,
@@ -146,6 +151,7 @@ func (r *SettingsRepository) Update(ctx context.Context, input *models.SettingsI
 		&settings.EditorEnableSnippets,
 		&settings.EditorEnableLiveAutocompletion,
 		&settings.MarkdownFontSize,
+		&settings.ExcludeFirstLineOnCopy,
 		&settings.CreatedAt,
 		&settings.UpdatedAt,
 	)

--- a/internal/services/snippet_service.go
+++ b/internal/services/snippet_service.go
@@ -336,7 +336,20 @@ func (s *SnippetService) List(ctx context.Context, filter models.SnippetFilter) 
 		filter.SortOrder = "desc"
 	}
 
-	return s.repo.List(ctx, filter)
+	response, err := s.repo.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load files for each snippet
+	if s.fileRepo != nil && len(response.Data) > 0 {
+		for i := range response.Data {
+			files, _ := s.fileRepo.GetBySnippetID(ctx, response.Data[i].ID)
+			response.Data[i].Files = files
+		}
+	}
+
+	return response, nil
 }
 
 // ToggleFavorite toggles the favorite status of a snippet

--- a/internal/web/static/css/components/snippets.css
+++ b/internal/web/static/css/components/snippets.css
@@ -141,6 +141,93 @@
   gap: 0.75rem;
 }
 
+.snippet-card-copy-btn {
+  background: none;
+  border: none;
+  padding: 0.25rem;
+  cursor: pointer;
+  color: var(--pico-muted-color);
+  transition: color 0.15s, transform 0.15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.25rem;
+}
+
+.snippet-card-copy-btn:hover {
+  color: var(--snipo-primary);
+  background: var(--pico-card-background-color);
+  transform: scale(1.1);
+}
+
+.snippet-card-copy-btn:active {
+  transform: scale(0.95);
+}
+
+.snippet-card-copy-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.snippet-card-copy-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 0.25rem);
+  background: var(--pico-card-background-color);
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: 0.375rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  min-width: 180px;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 100;
+}
+
+.snippet-card-copy-menu-header {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--pico-muted-color);
+  border-bottom: 1px solid var(--pico-muted-border-color);
+  background: var(--pico-background-color);
+}
+
+.snippet-card-copy-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.7rem;
+  color: var(--pico-contrast);
+  text-align: left;
+  transition: background 0.15s, color 0.15s;
+}
+
+.snippet-card-copy-menu-item:hover {
+  background: var(--pico-background-color);
+  color: var(--snipo-primary);
+}
+
+.snippet-card-copy-menu-item svg {
+  flex-shrink: 0;
+  color: var(--pico-muted-color);
+}
+
+.snippet-card-copy-menu-item:hover svg {
+  color: var(--snipo-primary);
+}
+
+.snippet-card-copy-menu-item span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 @media (max-width: 768px) {
   .snippet-grid {
     grid-template-columns: 1fr;

--- a/internal/web/static/js/components/snippets-app.js
+++ b/internal/web/static/js/components/snippets-app.js
@@ -387,6 +387,45 @@ export function initSnippetsApp(Alpine) {
       return result;
     },
 
+    // Helper methods for snippet cards
+    async copySnippetFromCard(snippet) {
+      try {
+        let contentToCopy = snippet.content;
+        
+        // Check if setting to exclude first line is enabled
+        if (this.settings?.exclude_first_line_on_copy) {
+          const lines = contentToCopy.split('\n');
+          if (lines.length > 1) {
+            contentToCopy = lines.slice(1).join('\n');
+          }
+        }
+        
+        await navigator.clipboard.writeText(contentToCopy);
+        showToast('Copied to clipboard');
+      } catch (err) {
+        showToast('Failed to copy', 'error');
+      }
+    },
+
+    async copyFileFromCard(snippet, file) {
+      try {
+        let contentToCopy = file.content;
+        
+        // Check if setting to exclude first line is enabled
+        if (this.settings?.exclude_first_line_on_copy) {
+          const lines = contentToCopy.split('\n');
+          if (lines.length > 1) {
+            contentToCopy = lines.slice(1).join('\n');
+          }
+        }
+        
+        await navigator.clipboard.writeText(contentToCopy);
+        showToast(`Copied ${file.filename} to clipboard`);
+      } catch (err) {
+        showToast('Failed to copy', 'error');
+      }
+    },
+
     // Utility methods exposed to component
     highlightAll,
     highlightCode,

--- a/internal/web/static/js/components/snippets/editor-mixin.js
+++ b/internal/web/static/js/components/snippets/editor-mixin.js
@@ -237,7 +237,17 @@ export const editorMixin = {
 
   async copyToClipboard(snippet) {
     try {
-      await navigator.clipboard.writeText(snippet.content);
+      let contentToCopy = snippet.content;
+      
+      // Check if setting to exclude first line is enabled
+      if (this.settings?.exclude_first_line_on_copy) {
+        const lines = contentToCopy.split('\n');
+        if (lines.length > 1) {
+          contentToCopy = lines.slice(1).join('\n');
+        }
+      }
+      
+      await navigator.clipboard.writeText(contentToCopy);
       showToast('Copied to clipboard');
     } catch (err) {
       showToast('Failed to copy', 'error');

--- a/internal/web/templates/components/modals.html
+++ b/internal/web/templates/components/modals.html
@@ -123,6 +123,15 @@
                         <strong>Note:</strong> API token operations always require password verification for security.
                     </p>
                 </div>
+                <div class="editor-field" style="margin-top: 1rem;">
+                    <label class="checkbox-label">
+                        <input type="checkbox" x-model="settings.exclude_first_line_on_copy" @change="updateSettings()">
+                        <span>Exclude First Line When Copying</span>
+                    </label>
+                    <p class="text-sm text-muted" style="margin-top: 0.25rem;">
+                        When copying snippets, automatically exclude the first line (useful for shebang lines like <code>#!/usr/bin/bash</code> or <code>&lt;?php</code>).
+                    </p>
+                </div>
             </div>
 
             <!-- Appearance tab -->

--- a/internal/web/templates/components/snippets-list.html
+++ b/internal/web/templates/components/snippets-list.html
@@ -20,19 +20,20 @@
     <div :class="viewMode === 'list' ? 'snippet-list-view' : 'snippet-grid'"
         x-show="!loading && snippets.length > 0">
         <template x-for="snippet in snippets" :key="snippet.id">
-            <article class="snippet-card" @click="viewSnippet(snippet)">
-                <div class="snippet-card-header">
-                    <h3 class="snippet-card-title" x-text="snippet.title"></h3>
-                    <span class="snippet-card-language"
-                        :style="{ background: getLanguageColor(snippet.language) }"
-                        x-text="snippet.language"></span>
-                </div>
+            <article class="snippet-card">
+                <div @click="viewSnippet(snippet)" style="cursor: pointer;">
+                    <div class="snippet-card-header">
+                        <h3 class="snippet-card-title" x-text="snippet.title"></h3>
+                        <span class="snippet-card-language"
+                            :style="{ background: getLanguageColor(snippet.language) }"
+                            x-text="snippet.language"></span>
+                    </div>
 
-                <!-- Show description if exists, otherwise show first 2 lines of code -->
-                <p class="snippet-card-description" x-show="snippet.description" x-text="snippet.description">
-                </p>
-                <pre class="snippet-card-preview"
-                    x-show="!snippet.description"><code x-text="snippet.content.split('\n').slice(0, 2).join('\n')"></code></pre>
+                    <!-- Show description if exists, otherwise show first 2 lines of code -->
+                    <p class="snippet-card-description" x-show="snippet.description" x-text="snippet.description">
+                    </p>
+                    <pre class="snippet-card-preview" x-show="!snippet.description"><code x-text="snippet.content.split('\n').slice(0, 2).join('\n')"></code></pre>
+                </div>
 
                 <div class="snippet-card-footer">
                     <div class="snippet-card-tags">
@@ -44,6 +45,52 @@
                         </template>
                     </div>
                     <div class="snippet-card-meta">
+                        <!-- Single file: simple copy button -->
+                        <button x-show="!snippet.files || snippet.files.length <= 1" 
+                                class="snippet-card-copy-btn" 
+                                @click.stop="copySnippetFromCard(snippet)" 
+                                title="Copy code">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        </button>
+                        
+                        <!-- Multiple files: dropdown menu -->
+                        <div x-show="snippet.files && snippet.files.length > 1" 
+                             class="snippet-card-copy-dropdown"
+                             x-data="{ open: false }"
+                             @click.outside="open = false">
+                            <button class="snippet-card-copy-btn" 
+                                    @click.stop="open = !open" 
+                                    :title="'Copy file (' + snippet.files.length + ' files)'">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                </svg>
+                                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-left: 2px;">
+                                    <polyline points="6 9 12 15 18 9"></polyline>
+                                </svg>
+                            </button>
+                            <div x-show="open" 
+                                 x-cloak
+                                 class="snippet-card-copy-menu"
+                                 @click.stop>
+                                <div class="snippet-card-copy-menu-header">Copy file:</div>
+                                <template x-for="(file, index) in snippet.files" :key="file.id || index">
+                                    <button class="snippet-card-copy-menu-item"
+                                            @click="copyFileFromCard(snippet, file); open = false"
+                                            :title="'Copy ' + file.filename">
+                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                            <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
+                                            <polyline points="13 2 13 9 20 9"></polyline>
+                                        </svg>
+                                        <span x-text="file.filename"></span>
+                                    </button>
+                                </template>
+                            </div>
+                        </div>
+                        
                         <span x-show="snippet.is_favorite" title="Favorite">
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"
                                 stroke="currentColor" stroke-width="2">

--- a/migrations/006_add_exclude_first_line_setting.sql
+++ b/migrations/006_add_exclude_first_line_setting.sql
@@ -1,0 +1,4 @@
+-- Add exclude_first_line_on_copy setting
+-- Migration: 006
+
+ALTER TABLE settings ADD COLUMN exclude_first_line_on_copy BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
This PR implements the feature requests in #87 


### Features Added

- **Copy button on snippet cards**: Quick one-click copy from the overview page
- **Multi-file snippet support**: Dropdown menu to select which file to copy when snippet has multiple files
- **Exclude first line setting**: Optional setting to automatically exclude first line when copying (useful for shebang lines like `#!/usr/bin/bash`)

### Changes

**Frontend:**
- Added copy button to snippet card footer with dropdown for multi-file snippets
- Implemented file selection UI with upward-opening dropdown menu
- Added "Exclude First Line When Copying" setting in General settings tab


**Backend:**
- Added `exclude_first_line_on_copy` field to Settings model
- Updated settings repository queries to support new field
- Modified snippet list endpoint to include files data
- Created database migration to add this settings to database fields
