### PR TITLE
fix: add configurable database memory settings to resolve "out of memory" errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,19 @@ SNIPO_TRUST_PROXY=false
 
 # Database
 SNIPO_DB_PATH=/data/snipo.db
+SNIPO_DB_MAX_CONNS=1
+SNIPO_DB_BUSY_TIMEOUT=5000
+SNIPO_DB_JOURNAL=WAL
+SNIPO_DB_SYNC=NORMAL
+
+# Database Memory Settings (adjust based on your system resources)
+# Reduce these values if experiencing "out of memory" database errors
+SNIPO_DB_MMAP_SIZE=268435456    # 256MB memory-mapped I/O (reduce if experiencing memory issues)
+SNIPO_DB_CACHE_SIZE=-2000        # 2MB cache (negative value = KB, reduce if needed)
+
+# For systems with memory constraints, try:
+# SNIPO_DB_MMAP_SIZE=67108864    # 64MB
+# SNIPO_DB_CACHE_SIZE=-1000      # 1MB
 
 # Authentication (REQUIRED)
 # OPTION 1 (Recommended): Use pre-hashed password for better security

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -95,6 +95,8 @@ func runServer() {
 		BusyTimeout:     cfg.Database.BusyTimeout,
 		JournalMode:     cfg.Database.JournalMode,
 		SynchronousMode: cfg.Database.SynchronousMode,
+		MMapSize:        cfg.Database.MMapSize,
+		CacheSize:       cfg.Database.CacheSize,
 	}, logger)
 	if err != nil {
 		logger.Error("failed to connect to database", "error", err)
@@ -248,6 +250,8 @@ func runMigrations() {
 		BusyTimeout:     cfg.Database.BusyTimeout,
 		JournalMode:     cfg.Database.JournalMode,
 		SynchronousMode: cfg.Database.SynchronousMode,
+		MMapSize:        cfg.Database.MMapSize,
+		CacheSize:       cfg.Database.CacheSize,
 	}, logger)
 	if err != nil {
 		logger.Error("failed to connect to database", "error", err)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,12 @@
 # 3. Enable network isolation (uncomment networks section below)
 # 4. Use a reverse proxy with HTTPS (nginx, traefik, caddy)
 # 5. Regularly update the image and rotate passwords
+#
+# DATABASE MEMORY CONFIGURATION:
+# For production environments with limited resources, consider reducing database memory usage:
+# Add these environment variables to prevent "out of memory" errors:
+#   - SNIPO_DB_MMAP_SIZE=67108864    # 64MB instead of 256MB
+#   - SNIPO_DB_CACHE_SIZE=-1000      # 1MB instead of 2MB
 
 services:
   snipo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,13 @@ services:
       # - SNIPO_DB_BUSY_TIMEOUT=5000
       # - SNIPO_DB_JOURNAL=WAL
       # - SNIPO_DB_SYNC=NORMAL
+      # Optional: Database memory settings (adjust based on system resources)
+      # Reduce these values if experiencing "out of memory" database errors
+      # - SNIPO_DB_MMAP_SIZE=268435456    # 256MB memory-mapped I/O
+      # - SNIPO_DB_CACHE_SIZE=-2000        # 2MB cache (negative value = KB)
+      # For systems with memory constraints, try:
+      # - SNIPO_DB_MMAP_SIZE=67108864     # 64MB
+      # - SNIPO_DB_CACHE_SIZE=-1000       # 1MB
       # Optional: Authentication rate limiting
       # - SNIPO_RATE_LIMIT=100
       # - SNIPO_RATE_WINDOW=1m


### PR DESCRIPTION
Fixes SQLite "out of memory (14)" database connection errors by making database memory settings configurable.
 
**Problem**: Users get `unable to open database file: out of memory (14)` error due to excessive default memory settings (256MB mmap + 2MB cache).
 
**Solution**: Added configurable environment variables:
- `SNIPO_DB_MMAP_SIZE`: Memory-mapped I/O size (default: 256MB)
- `SNIPO_DB_CACHE_SIZE`: Cache size in KB (default: 2MB)
 
**Fix for affected users**:
```bash
SNIPO_DB_MMAP_SIZE=67108864    # 64MB instead of 256MB
SNIPO_DB_CACHE_SIZE=-1000      # 1MB instead of 2MB
