### PR TITLE
fix: UI polish - text clipping, modal flicker, cancel button, copy alignment, Gist indicator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-04-08
+
+### Fixed
+- **Textarea auto-resize**: `autoResizeTextarea` now reads the element's computed `max-height` instead of a hardcoded cap, so the title input (120 px) and description textarea (80 px) each respect their own CSS constraint
+- **Cancel button invisible in light theme**: Modal cancel buttons (`modal-footer button:first-child`) now use `--snipo-text-primary` instead of `--pico-color`, which Pico v2 overrides to white on button elements
+- **Modal flicker on load/navigation**: Added `x-cloak` to the Token Password and Disable Login Password confirmation overlays, which were briefly visible before Alpine.js initialised
+- **Dropdown text clipping**: Removed the `height: 40px` constraint from `.editor-field` inputs and selects; elements now auto-size from padding alone, eliminating the tight content area that clipped text at the bottom border. `::file-selector-button` vertical padding reduced to match
+- **Copy button misalignment**: Added `display: inline-flex; align-items: center` to `.dropdown` so the copy dropdown wrapper aligns with sibling `btn-action` buttons in the editor toolbar
+- **Gist toggle in preview mode**: Replaced the interactive checkbox/switch with a read-only status indicator matching the Public/Private indicator style; Gist sync can now only be changed from edit mode
+
+### Changed
+- New/Edit Folder modal: inputs and buttons use a compact size (`btn-compact`) for a less heavy feel
+
 ## [1.4.0] - 2026-04-07
 
 ### Added

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Current is the current version of the application
-const Current = "1.4.0"
+const Current = "1.4.1"

--- a/internal/web/static/css/components/buttons.css
+++ b/internal/web/static/css/components/buttons.css
@@ -142,6 +142,8 @@
 /* Dropdown menu */
 .dropdown {
   position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .dropdown-menu {

--- a/internal/web/static/css/components/modals.css
+++ b/internal/web/static/css/components/modals.css
@@ -488,7 +488,6 @@
   color: var(--pico-color);
   transition: all 0.15s;
   line-height: 1.5;
-  height: 40px;
   box-sizing: border-box;
 }
 
@@ -504,12 +503,11 @@
   border-radius: 0.375rem;
   background: var(--pico-card-background-color);
   color: var(--pico-color);
-  height: 40px;
   box-sizing: border-box;
 }
 
 .editor-field input[type="file"]::file-selector-button {
-  padding: 0.5rem 0.75rem;
+  padding: 0.35rem 0.75rem;
   font-size: 0.8rem;
   margin-right: 0.5rem;
   background: var(--pico-muted-border-color);
@@ -606,7 +604,7 @@
 .modal-footer button:first-child {
   background: transparent;
   border: 1px solid var(--pico-muted-border-color);
-  color: var(--pico-color);
+  color: var(--snipo-text-primary);
 }
 
 .modal-footer button:first-child:hover {

--- a/internal/web/static/js/utils/helpers.js
+++ b/internal/web/static/js/utils/helpers.js
@@ -27,8 +27,10 @@ export function autoResizeSelect(element) {
 // Auto-resize textarea
 export function autoResizeTextarea(el) {
   if (!el) return;
+  const maxH = parseFloat(getComputedStyle(el).maxHeight);
+  const cap = isNaN(maxH) ? 200 : maxH;
   el.style.height = 'auto';
-  el.style.height = Math.min(el.scrollHeight, 80) + 'px';
+  el.style.height = Math.min(el.scrollHeight, cap) + 'px';
 }
 
 // Format date for display

--- a/internal/web/templates/components/editor.html
+++ b/internal/web/templates/components/editor.html
@@ -201,16 +201,14 @@
                     <span x-text="editingSnippet.is_public ? 'Public' : 'Private'"></span>
                 </div>
             </div>
-            <!-- Gist Sync toggle in preview mode -->
+            <!-- Gist Sync indicator in preview mode (read-only indicator) -->
             <div class="preview-meta-item" x-show="editingSnippet?.id && isGistConfigured()">
-                <label class="gist-toggle-switch-preview" title="Sync this snippet to GitHub Gist">
-                    <input type="checkbox" :checked="isGistSyncEnabled(editingSnippet.id)"
-                        @change="toggleGistSyncForSnippet(editingSnippet.id)">
-                    <div class="gist-switch-track">
-                        <div class="gist-switch-thumb"></div>
-                    </div>
-                    <span>Gist</span>
-                </label>
+                <div class="preview-public-indicator" :class="{ 'is-public': isGistSyncEnabled(editingSnippet.id) }">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="13" height="13">
+                        <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+                    </svg>
+                    <span x-text="isGistSyncEnabled(editingSnippet.id) ? 'Gist' : 'No Gist'"></span>
+                </div>
                 <a x-show="getGistUrl(editingSnippet.id)" :href="getGistUrl(editingSnippet.id)" target="_blank"
                     class="gist-link-icon" title="View on GitHub">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12">

--- a/internal/web/templates/components/modals.html
+++ b/internal/web/templates/components/modals.html
@@ -776,7 +776,8 @@
         <div class="modal-body">
             <div class="editor-field">
                 <label>Folder Name</label>
-                <input type="text" x-model="editingFolder.name" @keydown.enter="saveFolder()" autofocus>
+                <input type="text" x-model="editingFolder.name" @keydown.enter="saveFolder()" autofocus
+                    style="padding: 0.375rem 0.625rem; font-size: 0.8rem;">
             </div>
             <div class="editor-field" x-show="!editingFolder?.id">
                 <label>Parent Folder (optional)</label>
@@ -789,8 +790,8 @@
             </div>
         </div>
         <div class="modal-footer">
-            <button @click="showFolderModal = false">Cancel</button>
-            <button class="btn-primary" @click="saveFolder()">Save</button>
+            <button class="btn-compact" @click="showFolderModal = false">Cancel</button>
+            <button class="btn-primary btn-compact" @click="saveFolder()">Save</button>
         </div>
     </div>
 </div>

--- a/internal/web/templates/components/modals.html
+++ b/internal/web/templates/components/modals.html
@@ -1017,7 +1017,7 @@
 </div>
 
 <!-- Token Password Confirmation Modal (unified for create and delete) -->
-<div x-show="tokenPasswordAction !== null" class="snipo-modal-overlay" style="z-index: 1001;"
+<div x-show="tokenPasswordAction !== null" x-cloak class="snipo-modal-overlay" style="z-index: 1001;"
     @click.self="cancelTokenPassword()" x-transition:enter="transition ease-out duration-200"
     x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
     x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100"
@@ -1098,7 +1098,7 @@
 </div>
 
 <!-- Disable Login Password Confirmation Modal -->
-<div x-show="showDisableLoginPassword" class="snipo-modal-overlay" style="z-index: 1001;"
+<div x-show="showDisableLoginPassword" x-cloak class="snipo-modal-overlay" style="z-index: 1001;"
     @click.self="cancelDisableLoginPassword()" x-transition:enter="transition ease-out duration-200"
     x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
     x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snipo-frontend-vendor",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Frontend vendor dependencies for Snipo - managed locally for privacy",
   "private": true,
   "scripts": {


### PR DESCRIPTION

This PR fixes six UI bugs carried over from v1.4.0 and makes two small UX improvements.

### Bug Fixes
- **Textarea auto-resize**: [autoResizeTextarea](cci:1://file:///home/melashri/projects/snipo/internal/web/static/js/utils/helpers.js:26:0-33:1) now respects the element's own CSS `max-height` instead of a hardcoded 80 px cap.
- **Cancel button invisible (light theme)**: modal cancel buttons now use `--snipo-text-primary`; Pico v2 overrides `--pico-color` to white on `<button>` elements.
- **Modal flicker on load/navigation**: added `x-cloak` to the Token Password and Disable Login Password overlays that were missing it.
- **Dropdown text clipping**: removed the artificial `height: 40px` from `.editor-field` inputs/selects so they auto-size from padding; fixes text cut off by the bottom border.
- **Copy button misalignment**: `.dropdown` wrapper now uses `display: inline-flex; align-items: center` to sit flush with sibling toolbar buttons.
- **Gist toggle in preview mode**: replaced the interactive switch with a read-only status indicator (same pattern as Public/Private); Gist sync is only editable in edit mode.

### UX Improvements
- New/Edit Folder modal uses compact-sized inputs and buttons.

