### PR TITLE
fix: bump Go versions and add USER directive to Dockerfile.hardened

### DIFF
--- a/Dockerfile.hardened
+++ b/Dockerfile.hardened
@@ -88,6 +88,9 @@ ENV SNIPO_HOST=0.0.0.0 \
     SNIPO_DB_PATH=/data/snipo.db \
     SNIPO_LOG_FORMAT=json
 
+# Run as non-root user (UID 65532, standard for DHI/distroless images)
+USER 65532
+
 # Run the server
 ENTRYPOINT ["/snipo"]
 CMD ["serve"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/MohamedElashri/snipo
 
-go 1.25.0
+go 1.25.11
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0

--- a/tui/go.mod
+++ b/tui/go.mod
@@ -1,6 +1,6 @@
 module github.com/MohamedElashri/snipo/tui
 
-go 1.24.2
+go 1.24.13
 
 require (
 	github.com/alecthomas/chroma/v2 v2.21.1


### PR DESCRIPTION
- Update go.mod Go version from 1.25.0 → 1.25.11 and tui/go.mod from 1.24.2 → 1.24.13 to patch 79 stdlib CVEs (1 CRITICAL, 29 HIGH, 44 MEDIUM, 4 LOW)
- Add USER 65532 to Dockerfile.hardened to fix DS-0002 misconfiguration (container running as root)