### PR TITLE
fix: resolve mobile editor layout overlap and toolbar stacking

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-07-11
+
+### Fixed
+- Resolve mobile editor layout overlap and toolbar row stacking
+
 ## [1.7.0] - 2026-07-04
 
 ### Removed

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Current is the current version of the application
-const Current = "1.7.0"
+const Current = "1.7.1"

--- a/internal/web/static/css/components/editor.css
+++ b/internal/web/static/css/components/editor.css
@@ -1,15 +1,17 @@
 /* Editor - Code editor and preview styles */
 
 .editor-container {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 60px);
   min-width: 0;
   overflow: hidden;
 }
 
 .editor-toolbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
   padding: 0.25rem 0.5rem;
@@ -743,6 +745,7 @@
 }
 
 .editor-description-under-title {
+  flex: 0 0 100%;
   min-height: 30px;
   max-height: 72px;
   padding: 0.3rem 0.5rem;
@@ -1332,35 +1335,43 @@
 
 /* Mobile: ≤ 640px */
 @media (max-width: 640px) {
-  .editor-container {
-    height: calc(100vh - 56px);
-  }
-
   .editor-toolbar {
     padding: 0.15rem 0.35rem;
-    gap: 0.25rem;
+    gap: 0.2rem;
     flex-wrap: wrap;
   }
 
   .editor-toolbar > .btn-icon {
     order: 1;
-  }
-
-  .editor-toolbar-actions {
-    order: 2;
-    gap: 0.1rem;
+    flex: 0 0 auto;
   }
 
   .editor-title-display {
-    order: 3;
-    flex: 0 0 100%;
+    order: 1;
+    flex: 1;
+    min-width: 0;
     margin: 0.1rem 0;
   }
 
   .editor-title-wrapper {
+    order: 2;
+    flex: 0 0 100%;
+  }
+
+  .editor-description-under-title {
     order: 3;
     flex: 0 0 100%;
-    gap: 0.25rem;
+    min-height: 32px;
+    max-height: 56px;
+    font-size: 0.8rem;
+    padding: 0.3rem 0.5rem;
+  }
+
+  .editor-toolbar-actions {
+    order: 4;
+    flex: 0 0 100%;
+    gap: 0.1rem;
+    justify-content: flex-end;
   }
 
   .editor-toolbar-actions .btn-action span {
@@ -1381,13 +1392,6 @@
     padding: 0.35rem 0.5rem;
     min-height: 38px;
     max-height: 80px;
-  }
-
-  .editor-description-under-title {
-    min-height: 32px;
-    max-height: 56px;
-    font-size: 0.8rem;
-    padding: 0.3rem 0.5rem;
   }
 
   .file-bar {

--- a/internal/web/static/css/components/layout.css
+++ b/internal/web/static/css/components/layout.css
@@ -10,9 +10,10 @@
   margin-left: var(--sidebar-width);
   display: flex;
   flex-direction: column;
-  min-height: 0; /* Allow it to shrink when needed */
+  min-height: 0;
   min-width: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .main-content.expanded {

--- a/internal/web/static/css/components/sidebar.css
+++ b/internal/web/static/css/components/sidebar.css
@@ -293,12 +293,14 @@
 @media (max-width: 768px) {
   .sidebar {
     transform: translateX(-100%);
+    resize: none;
+    width: var(--sidebar-width);
+    max-width: 80vw;
   }
 
   .sidebar.open {
     transform: translateX(0);
   }
-
 }
 
 /* Mobile sidebar overlay */

--- a/internal/web/static/css/components/snippets.css
+++ b/internal/web/static/css/components/snippets.css
@@ -1,6 +1,9 @@
 /* Snippets - Snippet list and card styles */
 
 .snippet-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   padding: 1.5rem;
 }
 

--- a/internal/web/templates/components/editor.html
+++ b/internal/web/templates/components/editor.html
@@ -22,13 +22,16 @@
                 x-model="editingSnippet.title" placeholder="Snippet title..." rows="1"
                 @input="scheduleAutoSave(); autoResizeTextarea($event.target)"
                 x-init="$watch('isEditing', (v) => { if(v) $nextTick(() => autoResizeTextarea($el)) })"></textarea>
-            <textarea x-model="editingSnippet.description"
-                :class="{ 'rtl': isArabicText(editingSnippet.description) }"
-                placeholder="Description (optional)" rows="1"
-                class="description-textarea editor-description-under-title"
-                @input="scheduleAutoSave(); autoResizeTextarea($event.target)"
-                x-init="$watch('isEditing', (v) => { if(v) $nextTick(() => autoResizeTextarea($el)) })"></textarea>
         </div>
+
+        <!-- Description (edit mode, separate element for mobile row layout) -->
+        <textarea x-model="editingSnippet.description"
+            :class="{ 'rtl': isArabicText(editingSnippet.description) }"
+            placeholder="Description (optional)" rows="1"
+            class="description-textarea editor-description-under-title"
+            x-show="isEditing"
+            @input="scheduleAutoSave(); autoResizeTextarea($event.target)"
+            x-init="$watch('isEditing', (v) => { if(v) $nextTick(() => autoResizeTextarea($el)) })"></textarea>
 
         <div class="editor-toolbar-actions" :class="{ 'editing': isEditing }">
             <div class="editor-actions-row">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snipo-frontend-vendor",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Frontend vendor dependencies for Snipo - managed locally for privacy",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This PR fixes the mobile editing UI where the toolbar items (title, description, action buttons) were overlapping on narrow screens.
