### PR TITLE
fix: sanitize Host header in pagination links to prevent injection

### DIFF
--- a/internal/api/handlers/response.go
+++ b/internal/api/handlers/response.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/MohamedElashri/snipo/internal/api/middleware"
@@ -102,9 +104,35 @@ func getMeta(r *http.Request) *Meta {
 	}
 }
 
+// sanitizeHost validates and returns a sanitized host, falling back to "localhost" on invalid input.
+func sanitizeHost(host string) string {
+	if host == "" || len(host) > 255 || strings.Contains(host, "#") {
+		return "localhost"
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if host == "" {
+		return "localhost"
+	}
+	for i := 0; i < len(host); i++ {
+		c := host[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '-' || c == ':') {
+			if i == 0 && c == '[' {
+				continue
+			}
+			if c == ']' && i == len(host)-1 {
+				continue
+			}
+			return "localhost"
+		}
+	}
+	return host
+}
+
 // buildPaginationLinks generates navigation links for pagination
 func buildPaginationLinks(r *http.Request, page, limit, total int) *PaginationLinks {
-	baseURL := fmt.Sprintf("%s://%s%s", scheme(r), r.Host, r.URL.Path)
+	baseURL := fmt.Sprintf("%s://%s%s", scheme(r), sanitizeHost(r.Host), r.URL.Path)
 	query := r.URL.Query()
 
 	// Self link

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -279,6 +279,29 @@ func SanitizeFilename(filename string) string {
 	return filename
 }
 
+// SanitizeForLog removes characters that could be used for log injection.
+// It strips control characters (including CR, LF) that could inject fake log entries.
+func SanitizeForLog(v string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' {
+			return -1
+		}
+		if r < 32 {
+			return -1
+		}
+		return r
+	}, v)
+}
+
+// TruncateForLog sanitizes a string for logging and truncates it to maxLen.
+func TruncateForLog(v string, maxLen int) string {
+	v = SanitizeForLog(v)
+	if len(v) > maxLen {
+		v = v[:maxLen] + "..."
+	}
+	return v
+}
+
 // ValidateFilename validates a filename for length and basic safety
 func ValidateFilename(filename string) ValidationErrors {
 	var errs ValidationErrors


### PR DESCRIPTION
`buildPaginationLinks` used `r.Host` directly when building URL references. A malicious Host header could poison pagination URLs with arbitrary origins (open redirect / phishing). Added `sanitizeHost()` that validates host character-by-character and rejects non-standard values.

Also adds `SanitizeForLog` and `TruncateForLog` helpers for future use.