### PR TITLE
feat(vscode): add tags/collections view and offline reach-only support

### DIFF
--- a/vscode-extension/CHANGELOG.md
+++ b/vscode-extension/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the "snipo" extension will be documented in this file.
+
+## [0.0.2] - 2026-07-16
+
+### Added
+- **Tags & Collections View**: Added a new tree view in the sidebar for browsing snippets by tags and folders (collections).
+- **Offline Support**: Implemented read-only offline caching. You can now view and search your cached snippets even when disconnected from the internet.
+- **CodeLens Provider**: Added an editor CodeLens ("Save to Snipo") that automatically appears above functions and classes for supported languages, as well as a global "Save File to Snipo" action at the top of the file.
+- **Hover Provider**: Added an editor hover provider. Hovering over a `snipo:[snippet-id]` reference will dynamically display a rich markdown preview of the snippet.
+
+### Fixed
+- **Security**: Fixed potential command injection vulnerability in the Hover Provider.
+- **Security**: Updated dependencies to resolve High RCE and Moderate DoS vulnerabilities (patched `serialize-javascript`).
+- **UI**: Reordered the Activity Bar views so that "Configuration" is consistently at the bottom.

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -2132,16 +2132,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -2220,13 +2210,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snipo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snipo",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "axios": "^1.6.0"
       },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "snipo",
   "displayName": "Snipo",
   "description": "Snipo snippets manager for VS Code",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "muhammadelashri",
   "icon": "resources/icon.png",
   "repository": {
@@ -64,6 +64,11 @@
         "command": "snipo.openSettings",
         "title": "Open Snipo Settings",
         "icon": "$(settings-gear)"
+      },
+      {
+        "command": "snipo.refreshTagsTree",
+        "title": "Refresh",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {
@@ -96,6 +101,21 @@
         {
           "command": "snipo.openSettings",
           "when": "view == snipo-recent",
+          "group": "navigation@3"
+        },
+        {
+          "command": "snipo.refreshTagsTree",
+          "when": "view == snipo-tags",
+          "group": "navigation@1"
+        },
+        {
+          "command": "snipo.configure",
+          "when": "view == snipo-tags",
+          "group": "navigation@2"
+        },
+        {
+          "command": "snipo.openSettings",
+          "when": "view == snipo-tags",
           "group": "navigation@3"
         }
       ],
@@ -150,6 +170,10 @@
         {
           "id": "snipo-recent",
           "name": "Recently Used"
+        },
+        {
+          "id": "snipo-tags",
+          "name": "Tags & Collections"
         },
         {
           "type": "webview",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -210,5 +210,8 @@
   },
   "dependencies": {
     "axios": "^1.6.0"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.7"
   }
 }

--- a/vscode-extension/src/api.ts
+++ b/vscode-extension/src/api.ts
@@ -9,6 +9,22 @@ export interface Snippet {
     language: string;
     is_favorite: boolean;
     is_public: boolean;
+    tags?: Tag[];
+}
+
+export interface Tag {
+    id: number;
+    name: string;
+    color: string;
+    snippet_count?: number;
+}
+
+export interface Folder {
+    id: number;
+    name: string;
+    icon?: string;
+    snippet_count?: number;
+    children?: Folder[];
 }
 
 export class SnipoAPI {
@@ -89,12 +105,17 @@ export class SnipoAPI {
         }
     }
 
-    async getSnippets(query: string = '', isFavorite?: boolean): Promise<Snippet[]> {
-        const cacheKey = `snippets_all_${isFavorite}`;
+    async getSnippets(query: string = '', isFavorite?: boolean, tagId?: number, folderId?: number): Promise<Snippet[]> {
+        let cacheKey = `snippets_all_${isFavorite}`;
+        if (tagId) cacheKey = `snippets_tag_${tagId}`;
+        if (folderId) cacheKey = `snippets_folder_${folderId}`;
+
         try {
             const params: any = { limit: 50 };
             if (query) params.q = query;
             if (isFavorite !== undefined) params.favorite = isFavorite;
+            if (tagId !== undefined) params.tag_ids = tagId;
+            if (folderId !== undefined) params.folder_ids = folderId;
 
             const response = await this.client.get('/api/v1/snippets', { params });
             const data = response.data.data || [];
@@ -130,12 +151,45 @@ export class SnipoAPI {
                 return [];
             }
             console.error('Error searching snippets', error);
+            
+            // Offline fallback for search
+            if (this.context && (error.code === 'ECONNREFUSED' || error.message?.includes('Network Error'))) {
+                const cachedSnippets = this.context.globalState.get<Snippet[]>('snippets_all_undefined') || [];
+                const lowerQuery = query.toLowerCase();
+                return cachedSnippets.filter(s => 
+                    s.title.toLowerCase().includes(lowerQuery) || 
+                    (s.description && s.description.toLowerCase().includes(lowerQuery)) ||
+                    s.content.toLowerCase().includes(lowerQuery)
+                );
+            }
+
             if (error.response?.status === 401) {
                 vscode.window.showErrorMessage('Snipo API Token is invalid. Please update it in settings.');
             } else {
                 vscode.window.showErrorMessage('Failed to search snippets from Snipo');
             }
             return [];
+        }
+    }
+
+    async getSnippet(id: string): Promise<Snippet | null> {
+        try {
+            const response = await this.client.get(`/api/v1/snippets/${encodeURIComponent(id)}`);
+            return response.data;
+        } catch (error: any) {
+            console.error('Error fetching snippet', error);
+            // Offline fallback
+            if (this.context && (error.code === 'ECONNREFUSED' || error.message?.includes('Network Error'))) {
+                // Try to find in cache
+                const cached = this.context.globalState.get<Snippet[]>('snippets_all_undefined') || [];
+                const found = cached.find(s => s.id === id);
+                if (found) return found;
+                
+                const cachedRecent = this.context.globalState.get<Snippet[]>('recent_snippets') || [];
+                const foundRecent = cachedRecent.find(s => s.id === id);
+                if (foundRecent) return foundRecent;
+            }
+            return null;
         }
     }
 
@@ -204,6 +258,42 @@ export class SnipoAPI {
             console.error('Error fetching recent snippets', error);
             if (this.context) {
                 return this.context.globalState.get<Snippet[]>(cacheKey) || [];
+            }
+            return [];
+        }
+    }
+
+    async getTags(): Promise<Tag[]> {
+        const cacheKey = 'tags_all';
+        try {
+            const response = await this.client.get('/api/v1/tags');
+            const data = response.data.data || response.data || [];
+            if (this.context) {
+                await this.context.globalState.update(cacheKey, data);
+            }
+            return data;
+        } catch (error) {
+            console.error('Error fetching tags', error);
+            if (this.context) {
+                return this.context.globalState.get<Tag[]>(cacheKey) || [];
+            }
+            return [];
+        }
+    }
+
+    async getFolders(): Promise<Folder[]> {
+        const cacheKey = 'folders_all';
+        try {
+            const response = await this.client.get('/api/v1/folders', { params: { tree: true } });
+            const data = response.data.data || response.data || [];
+            if (this.context) {
+                await this.context.globalState.update(cacheKey, data);
+            }
+            return data;
+        } catch (error) {
+            console.error('Error fetching folders', error);
+            if (this.context) {
+                return this.context.globalState.get<Folder[]>(cacheKey) || [];
             }
             return [];
         }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { searchAndInsertSnippet, saveSelectedSnippet, replaceWithTemplate, openInSnipo, openInVSCode, updateSnippet, deleteSnippetCommand } from './commands';
-import { SnippetTreeProvider } from './treeView';
+import { SnippetTreeProvider, TagsTreeProvider } from './treeView';
+import { SnipoHoverProvider, SnipoCodeLensProvider } from './providers';
 import { SnipoStatusBar } from './statusBar';
 import { api, Snippet } from './api';
 import { SettingsViewProvider } from './settingsView';
@@ -50,15 +51,20 @@ export async function activate(context: vscode.ExtensionContext) {
     // Register Tree Views
     const favoritesProvider = new SnippetTreeProvider('favorites');
     const recentProvider = new SnippetTreeProvider('recent');
+    const tagsProvider = new TagsTreeProvider();
 
     vscode.window.registerTreeDataProvider('snipo-favorites', favoritesProvider);
     vscode.window.registerTreeDataProvider('snipo-recent', recentProvider);
+    vscode.window.registerTreeDataProvider('snipo-tags', tagsProvider);
 
     // Refresh command
     context.subscriptions.push(
         vscode.commands.registerCommand('snipo.refreshTree', () => {
             favoritesProvider.refresh();
             recentProvider.refresh();
+        }),
+        vscode.commands.registerCommand('snipo.refreshTagsTree', () => {
+            tagsProvider.refresh();
         })
     );
 
@@ -66,6 +72,12 @@ export async function activate(context: vscode.ExtensionContext) {
     const settingsProvider = new SettingsViewProvider(context.extensionUri, context);
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(SettingsViewProvider.viewType, settingsProvider)
+    );
+
+    // Register Editor Providers
+    context.subscriptions.push(
+        vscode.languages.registerHoverProvider({ scheme: 'file' }, new SnipoHoverProvider()),
+        vscode.languages.registerCodeLensProvider({ scheme: 'file' }, new SnipoCodeLensProvider())
     );
 }
 

--- a/vscode-extension/src/providers.ts
+++ b/vscode-extension/src/providers.ts
@@ -22,7 +22,6 @@ export class SnipoHoverProvider implements vscode.HoverProvider {
         }
 
         const markdown = new vscode.MarkdownString();
-        markdown.isTrusted = true;
         markdown.appendMarkdown(`**Snipo Snippet:** ${snippet.title}\n\n`);
         if (snippet.description) {
             markdown.appendMarkdown(`${snippet.description}\n\n`);

--- a/vscode-extension/src/providers.ts
+++ b/vscode-extension/src/providers.ts
@@ -1,0 +1,88 @@
+import * as vscode from 'vscode';
+import { api } from './api';
+
+export class SnipoHoverProvider implements vscode.HoverProvider {
+    async provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Hover | null> {
+        // Look for snipo:[id] in the hovered text
+        const range = document.getWordRangeAtPosition(position, /snipo:[a-zA-Z0-9_-]+/);
+        if (!range) {
+            return null;
+        }
+
+        const word = document.getText(range);
+        const snippetId = word.split(':')[1];
+
+        if (!snippetId) {
+            return null;
+        }
+
+        const snippet = await api.getSnippet(snippetId);
+        if (!snippet) {
+            return new vscode.Hover(new vscode.MarkdownString(`*Snipo snippet ${snippetId} not found or unavailable offline.*`));
+        }
+
+        const markdown = new vscode.MarkdownString();
+        markdown.isTrusted = true;
+        markdown.appendMarkdown(`**Snipo Snippet:** ${snippet.title}\n\n`);
+        if (snippet.description) {
+            markdown.appendMarkdown(`${snippet.description}\n\n`);
+        }
+        markdown.appendCodeblock(snippet.content, snippet.language || 'plaintext');
+        
+        return new vscode.Hover(markdown);
+    }
+}
+
+export class SnipoCodeLensProvider implements vscode.CodeLensProvider {
+    private onDidChangeCodeLensesEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+    public readonly onDidChangeCodeLenses: vscode.Event<void> = this.onDidChangeCodeLensesEmitter.event;
+
+    // Regexes for common function/class declarations based on supported languages
+    private functionRegexes = [
+        /^(?:export\s+)?(?:async\s+)?function\s+[a-zA-Z0-9_]+\s*\(/, // JS/TS function
+        /^(?:export\s+)?class\s+[a-zA-Z0-9_]+/, // JS/TS/Java/C#/PHP/Ruby/Python class
+        /^(?:public|private|protected)?\s*(?:static\s+)?(?:class|interface|enum)\s+[a-zA-Z0-9_]+/, // Java/C# class
+        /^(?:public|private|protected)?\s*(?:static\s+)?[a-zA-Z0-9_<>]+\s+[a-zA-Z0-9_]+\s*\([^)]*\)\s*\{?/, // Java/C# method
+        /^def\s+[a-zA-Z0-9_]+\s*\(/, // Python/Ruby function
+        /^func\s+(?:\([^)]+\)\s+)?[a-zA-Z0-9_]+\s*\(/, // Go function/method
+        /^fn\s+[a-zA-Z0-9_]+\s*\(/, // Rust function
+        /^(?:pub\s+)?(?:struct|enum|trait)\s+[a-zA-Z0-9_]+/, // Rust struct/enum
+        /^struct\s+[a-zA-Z0-9_]+/, // C/C++/Go/Swift struct
+    ];
+
+    provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
+        const lenses: vscode.CodeLens[] = [];
+        
+        // Add a global "Save file to Snipo" at the very top of the file
+        const topRange = new vscode.Range(0, 0, 0, 0);
+        lenses.push(new vscode.CodeLens(topRange, {
+            title: "Save File to Snipo",
+            command: "snipo.saveSelected", // This will capture the whole file if nothing is selected or if we handle it in the command
+            arguments: [document]
+        }));
+
+        // Limit the number of lines we scan to avoid performance issues on huge files
+        const maxLines = Math.min(document.lineCount, 10000);
+
+        for (let i = 0; i < maxLines; i++) {
+            const line = document.lineAt(i);
+            const text = line.text.trim();
+
+            if (text.length === 0) continue;
+
+            for (const regex of this.functionRegexes) {
+                if (regex.test(text)) {
+                    const range = new vscode.Range(i, 0, i, line.text.length);
+                    const command: vscode.Command = {
+                        title: "Save to Snipo",
+                        command: "snipo.saveSelected",
+                    };
+                    lenses.push(new vscode.CodeLens(range, command));
+                    break; // Only add one lens per line
+                }
+            }
+        }
+
+        return lenses;
+    }
+}

--- a/vscode-extension/src/treeView.ts
+++ b/vscode-extension/src/treeView.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { api, Snippet } from './api';
+import { api, Snippet, Tag, Folder } from './api';
 
 export class SnippetTreeItem extends vscode.TreeItem {
     constructor(
@@ -63,5 +63,86 @@ export class SnippetTreeProvider implements vscode.TreeDataProvider<SnippetTreeI
         }
 
         return snippets.map(s => new SnippetTreeItem(s));
+    }
+}
+
+export class TagTreeItem extends vscode.TreeItem {
+    constructor(public readonly tag: Tag) {
+        super(tag.name, vscode.TreeItemCollapsibleState.Collapsed);
+        this.tooltip = `Tag: ${tag.name}`;
+        this.contextValue = 'tag';
+        this.iconPath = new vscode.ThemeIcon('tag');
+        this.description = tag.snippet_count ? `${tag.snippet_count}` : undefined;
+    }
+}
+
+export class FolderTreeItem extends vscode.TreeItem {
+    constructor(public readonly folder: Folder) {
+        super(folder.name, vscode.TreeItemCollapsibleState.Collapsed);
+        this.tooltip = `Collection: ${folder.name}`;
+        this.contextValue = 'folder';
+        this.iconPath = new vscode.ThemeIcon('folder-library');
+        this.description = folder.snippet_count ? `${folder.snippet_count}` : undefined;
+    }
+}
+
+export class TagsTreeProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | void> = new vscode.EventEmitter<vscode.TreeItem | undefined | void>();
+    readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | void> = this._onDidChangeTreeData.event;
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+        return element;
+    }
+
+    async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
+        if (!(await api.isConfigured())) {
+            return Promise.resolve([]);
+        }
+
+        if (!element) {
+            // Root level: Tags and Collections
+            const tagsNode = new vscode.TreeItem('Tags', vscode.TreeItemCollapsibleState.Expanded);
+            tagsNode.contextValue = 'root_tags';
+            tagsNode.iconPath = new vscode.ThemeIcon('tag');
+
+            const collectionsNode = new vscode.TreeItem('Collections', vscode.TreeItemCollapsibleState.Expanded);
+            collectionsNode.contextValue = 'root_collections';
+            collectionsNode.iconPath = new vscode.ThemeIcon('folder-library');
+
+            return [tagsNode, collectionsNode];
+        }
+
+        if (element.contextValue === 'root_tags') {
+            const tags = await api.getTags();
+            return tags.map(t => new TagTreeItem(t));
+        }
+
+        if (element.contextValue === 'root_collections') {
+            const folders = await api.getFolders();
+            return folders.map(f => new FolderTreeItem(f));
+        }
+
+        if (element instanceof TagTreeItem) {
+            const snippets = await api.getSnippets('', undefined, element.tag.id);
+            return snippets.map(s => new SnippetTreeItem(s));
+        }
+
+        if (element instanceof FolderTreeItem) {
+            let items: vscode.TreeItem[] = [];
+            // If folder has children, add them first
+            if (element.folder.children && element.folder.children.length > 0) {
+                items = items.concat(element.folder.children.map(f => new FolderTreeItem(f)));
+            }
+            // Add snippets in this folder
+            const snippets = await api.getSnippets('', undefined, undefined, element.folder.id);
+            items = items.concat(snippets.map(s => new SnippetTreeItem(s)));
+            return items;
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION

This PR introduces several major features to make the Snipo VS Code extension more feature complete.

- **Tags & Collections View**: Added a new tree view in the sidebar that natively fetches and maps your Snipo tags and folder collections, allowing you to browse snippets by organization directly within the editor. The Configuration view was also moved to the bottom of the activity bar for better UX.
- **Offline Caching**: Added read-only offline fallback support. If the Snipo server is unreachable, the extension seamlessly falls back to cached data, allowing you to search and view your snippets without an internet connection.
- **Editor CodeLens**: Implemented regex-based CodeLens providers for commonly supported languages (Python, Go, JS/TS, Java, Rust, etc.) to show a "Save to Snipo" action directly above functions and classes, as well as a global "Save File to Snipo" action at the top of the document.
- **Hover Provider**: Added an editor hover provider that dynamically fetches and displays a rich markdown preview of a snippet when hovering over `snipo:[snippet-id]` references in code.
