### PR TITLE
docs: clarify Snipo Argon2 hash format and Docker Compose escaping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
     environment:
       # Authentication: Use either hashed password (recommended) or plain password
       # Generate hash with: docker run --rm ghcr.io/mohamedelashri/snipo:latest hash-password your-password
+      # When using Docker Compose, escape each `$` as `$$`
+      # because Compose treats `$` as variable interpolation syntax.
+      # Example:
+      # SNIPO_MASTER_PASSWORD_HASH: "$$argon2id$$<salt>$$<hash>"
+
       # SNIPO_MASTER_PASSWORD_HASH=${SNIPO_MASTER_PASSWORD_HASH}
       # Or use the supported plaintext password configuration:
       - SNIPO_MASTER_PASSWORD=${SNIPO_MASTER_PASSWORD:-<Put_your_master_password_here>}


### PR DESCRIPTION
Tiny documentation fix.

Just added a small note explaining the Snipo hash format and the Docker Compose `$` escaping gotcha. :)

Thanks for maintaining this project!